### PR TITLE
nixos/sd-webui-forge: add sd-webui-forge module

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## Using this flake
 
 Add the following to your inputs:
+
 ```nix
 stable-diffusion-webui-nix = {
   url = "github:Janrupf/stable-diffusion-webui-nix/main";
@@ -13,8 +14,9 @@ stable-diffusion-webui-nix = {
 ```
 
 Then add the overlay to your system configuration:
+
 ```nix
-{ 
+{
   nixpkgs.overlays = [ stable-diffusion-webui-nix.overlays.default ];
 }
 ```
@@ -31,6 +33,25 @@ environment.systemPackages = [
 Afterwards you should have the command `stable-diffusion-webui` or `comfy-ui`
 available which launches the server.
 
+### Running as service
+
+This flake exposes the module `services.sd-webui-forge` that runs the forge webui as a systemd service.
+
+The available options are:
+
+```nix
+services.sd-webui-forge = {
+    enable = true;
+    user = "sd-webui-forge"; # The user that runs the service.
+    group = "sd-webui-forge"; # The group that runs the service.
+    dataDir = "/var/lib/sd-webui-forge"; # The directory that the webUI stores models and images in.
+    package = pkgs.stable-diffusion-webui.forge.cuda; # The package (cuda/rocm) that you want to use.
+    listen = true; # Whether to listen on all interfaces or only localhost.
+    port = 7860; # The port for the webUI.
+    extraArgs = "--cuda-malloc"; # Extra CLI args for the server.
+};
+```
+
 ### Quirks
 
 #### Where is my WebUI (for Forge) data?
@@ -46,9 +67,9 @@ by using `--base-directory /another/path` argument.
 #### This takes ages to compile...
 
 Running Stable Diffusion models requires CUDA and thus depends on packages which are
-by default not available in the NixOS cache. Add the 
-[cuda-maintainers](https://app.cachix.org/cache/cuda-maintainers) Cachix as a 
-substituter to your Nix configuration. See the 
+by default not available in the NixOS cache. Add the
+[cuda-maintainers](https://app.cachix.org/cache/cuda-maintainers) Cachix as a
+substituter to your Nix configuration. See the
 [NixOS Wiki](https://nixos.wiki/wiki/CUDA) for more information.
 
 ## Developing this flake/updating packages to a new version
@@ -61,9 +82,9 @@ Due to the nature of python package management, this flake is quite complex.
    to update the requirements metadata
 3. try running the package using `nix run .#package` (for example `nix run .#comfy.cuda`) and test everything
 
-NOTE: If you get an error that you have run out of disk space during step 2, your 
-`/tmp` is too small. Either increase the tmpfs size or run the command with `TMPDIR` 
-set to a different directory. Generally, if step 2 fails the temporary directory 
+NOTE: If you get an error that you have run out of disk space during step 2, your
+`/tmp` is too small. Either increase the tmpfs size or run the command with `TMPDIR`
+set to a different directory. Generally, if step 2 fails the temporary directory
 may not be deleted, you are free to `rm -rf` it, but it can be useful for inspecting
 why it failed.
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./comfy.nix
+    ./forge.nix
   ];
 
   config = {

--- a/modules/forge.nix
+++ b/modules/forge.nix
@@ -1,0 +1,175 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  inherit (builtins) toString;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    literalExpression
+    optionalAttrs
+    mkIf
+    ;
+  inherit (lib.types)
+    str
+    path
+    port
+    package
+    ;
+  inherit (lib.strings) escapeShellArg optionalString;
+  cfg = config.services.sd-webui-forge;
+in
+{
+  options.services.sd-webui-forge = {
+    enable = mkEnableOption "the stable diffusion Forge WebUI";
+
+    user = mkOption {
+      type = str;
+      default = "sd-webui-forge";
+      description = ''
+        User account under which the web server runs.
+
+        ::: {.note}
+        If left as the default value this user will automatically be created
+        on system activation, otherwise you are responsible for
+        ensuring the user exists before the service starts.
+        :::
+      '';
+    };
+
+    group = mkOption {
+      type = str;
+      default = "sd-webui-forge";
+      description = ''
+        Group account under which the web server runs.
+
+        ::: {.note}
+        If left as the default value this group will automatically be created
+        on system activation, otherwise you are responsible for
+        ensuring the user exists before the service starts.
+        :::
+      '';
+    };
+
+    dataDir = mkOption {
+      type = path;
+      default = "/var/lib/sd-webui-forge";
+      description = ''
+        The data directory for the service.
+
+        ::: {.note}
+        If left as the default value of `/var/lib/sd-webui-forge` this directory will automatically be created before the web
+        server starts, otherwise you are responsible for ensuring the directory exists with appropriate ownership and permissions.
+        :::
+      '';
+    };
+
+    package = mkOption {
+      type = package;
+      default = pkgs.stable-diffusion-webui.forge.cuda;
+      example = literalExpression "pkgs.stable-diffusion-webui.forge.cuda";
+      description = ''
+        Which package to user for the ComfyUI installation.
+      '';
+    };
+
+    listen = mkEnableOption "listening on 0.0.0.0";
+
+    port = mkOption {
+      type = port;
+      default = 7860;
+      description = ''
+        The port to bind the web interface to.
+      '';
+    };
+
+    extraArgs = mkOption {
+      type = str;
+      default = "";
+      example = "--cuda-malloc --skip-load-model-at-start";
+      description = "Extra CLI arguments that will be added to the sd-webui-forge command.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users = optionalAttrs (cfg.user == "sd-webui-forge") {
+      sd-webui-forge = {
+        description = "sd-webui-forge service user";
+        inherit (cfg) group;
+        isSystemUser = true;
+
+        # Access to GPU for CUDA
+        extraGroups = [ "video" ];
+      };
+    };
+
+    users.groups = lib.optionalAttrs (cfg.group == "sd-webui-forge") {
+      sd-webui-forge = { };
+    };
+
+    systemd.services.sd-webui-forge = {
+      description = "powerful and modular diffusion model GUI";
+
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      unitConfig.RequiresMountsFor = cfg.dataDir;
+
+      # Needed or forge will not start
+      path = [ pkgs.git ];
+
+      script = ''
+        exec ${cfg.package}/bin/stable-diffusion-webui \
+          --data-dir ${escapeShellArg cfg.dataDir} \
+          ${optionalString cfg.listen "--listen"} \
+          --port ${toString cfg.port} \
+          ${cfg.extraArgs}
+      '';
+
+      serviceConfig = lib.mkMerge [
+        {
+          Type = "simple";
+          Restart = "on-failure";
+          RestartSec = "5s";
+
+          User = cfg.user;
+          Group = cfg.group;
+
+          ReadWritePaths = [ cfg.dataDir ];
+
+          CapabilityBoundingSet = "";
+          NoNewPrivileges = true;
+
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          PrivateTmp = true;
+          ProtectHostname = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectControlGroups = true;
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+          ];
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          PrivateMounts = true;
+
+          SystemCallArchitectures = "native";
+          SystemCallFilter = "@system-service";
+        }
+        (lib.mkIf (cfg.dataDir == "/var/lib/sd-webui-forge") {
+          StateDirectory = "sd-webui-forge";
+          StateDirectoryMode = "0700";
+          CacheDirectory = "sd-webui-forge";
+        })
+      ];
+    };
+  };
+}


### PR DESCRIPTION
This PR closes #2 by providing `services.sd-webui-forge` that starts a systemd service for the forge webui.

I also added a section to the README about the option, but did not include your services.comfyUi option as I'm not sure if you are done with that. Feel free to revise whatever you need