### PR TITLE
fix: get comfy ui service running

### DIFF
--- a/modules/comfy.nix
+++ b/modules/comfy.nix
@@ -118,7 +118,7 @@ in
         export HF_HOME="$CACHE_DIRECTORY/huggingface/hub"
 
         exec ${cfg.package}/bin/comfy-ui \
-          --data-dir ${lib.strings.escapeShellArg cfg.dataDir} \
+          --base-directory ${lib.strings.escapeShellArg cfg.dataDir} \
           ${lib.strings.optionalString (cfg.listenHost != null) "--listen ${lib.strings.escapeShellArg cfg.listenHost}"} \
           --port ${builtins.toString cfg.listenPort}
       '';

--- a/modules/comfy.nix
+++ b/modules/comfy.nix
@@ -117,6 +117,9 @@ in
       script = ''
         export HF_HOME="$CACHE_DIRECTORY/huggingface/hub"
 
+        # comfy-ui will not start if this directory is not present.
+        mkdir -p ${cfg.dataDir}/custom_nodes
+
         exec ${cfg.package}/bin/comfy-ui \
           --base-directory ${lib.strings.escapeShellArg cfg.dataDir} \
           ${lib.strings.optionalString (cfg.listenHost != null) "--listen ${lib.strings.escapeShellArg cfg.listenHost}"} \


### PR DESCRIPTION
This PR fixes the comfy ui service not running - previously it would first crash on startup as the data directory argument was incorrectly set to `--data-directory` instead of `--base-directory`, and then crash because it could not find the `$DATA_DIRECTORY/custom_nodes` directory. I added the fixes in two separate commits but please let me know if I should squash them. Tested and works on my machine but I'm not super familiar with comfy ui so would appreciate some more comprehensive tests on your end