### PR TITLE
add directory permissions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ services.sd-webui-forge = {
     user = "sd-webui-forge"; # The user that runs the service.
     group = "sd-webui-forge"; # The group that runs the service.
     dataDir = "/var/lib/sd-webui-forge"; # The directory that the webUI stores models and images in.
+    dataPermissions = "0700" # presmissions for the dataDir directory
     package = pkgs.stable-diffusion-webui.forge.cuda; # The package (cuda/rocm) that you want to use.
     listen = true; # Whether to listen on all interfaces or only localhost.
     port = 7860; # The port for the webUI.

--- a/modules/comfy.nix
+++ b/modules/comfy.nix
@@ -30,7 +30,7 @@ in
           :::
         '';
       };
-      
+
       group = lib.mkOption {
         type = lib.types.str;
         default = "comfy-ui";
@@ -55,6 +55,19 @@ in
           ::: {.note}
           If left as the default value of `/var/lib/comfy-ui` this directory will automatically be created before the web
           server starts, otherwise you are responsible for ensuring the directory exists with appropriate ownership and permissions.
+          :::
+        '';
+      };
+
+      dataPermissions = lib.mkOption {
+        type = lib.types.str;
+        default = "0700";
+        description = ''
+          The permissions to set on the data directory.
+
+          ::: {.note}
+          Permissions for the data directory will be set to `rwx------` (0700) by default.
+          Only works for `/var/lib/comfy-ui` at this time.
           :::
         '';
       };
@@ -111,7 +124,7 @@ in
 
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      
+
       unitConfig.RequiresMountsFor = cfg.dataDir;
 
       script = ''
@@ -139,7 +152,7 @@ in
 
           CapabilityBoundingSet = "";
           NoNewPrivileges = true;
- 
+
           ProtectSystem = "strict";
           ProtectHome = true;
           PrivateTmp = true;
@@ -153,14 +166,13 @@ in
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
           PrivateMounts = true;
- 
+
           SystemCallArchitectures = "native";
           SystemCallFilter = "@system-service";
         }
         (lib.mkIf (cfg.dataDir == "/var/lib/comfy-ui") {
           StateDirectory = "comfy-ui";
-          StateDirectoryMode = "0700";
-
+          StateDirectoryMode = cfg.dataPermissions;
           CacheDirectory = "comfy-ui";
         })
       ];

--- a/modules/forge.nix
+++ b/modules/forge.nix
@@ -67,6 +67,19 @@ in
       '';
     };
 
+    dataPermissions = lib.mkOption {
+      type = lib.types.str;
+      default = "0700";
+      description = ''
+        The permissions to set on the data directory.
+
+        ::: {.note}
+        Permissions for the data directory will be set to `rwx------` (0700) by default.
+        Only works for `/var/lib/sd-webui-forge` at this time.
+        :::
+      '';
+    };
+
     package = mkOption {
       type = package;
       default = pkgs.stable-diffusion-webui.forge.cuda;
@@ -166,7 +179,7 @@ in
         }
         (lib.mkIf (cfg.dataDir == "/var/lib/sd-webui-forge") {
           StateDirectory = "sd-webui-forge";
-          StateDirectoryMode = "0700";
+          StateDirectoryMode = cfg.dataPermissions;
           CacheDirectory = "sd-webui-forge";
         })
       ];


### PR DESCRIPTION
Useful option for those running services on a server with an accompanying gallery service such as immich for browsing results. `0700` remains the default, with an option to change it to `0740` for instance to make the files available read-only to a gallery app in the same group.